### PR TITLE
Raise exceptions which set exit code when handled

### DIFF
--- a/lib/rmt/cli/systems.rb
+++ b/lib/rmt/cli/systems.rb
@@ -41,8 +41,8 @@ class RMT::CLI::Systems < RMT::CLI::Base
     target_system.destroy!
     puts _('Successfully removed system with login %{login}') % { login: target }
   rescue ActiveRecord::RecordNotDestroyed
-    puts _('System with login %{login} cannot be removed.') % { login: target }
+    raise RMT::CLI::Error.new(_('System with login %{login} cannot be removed.') % { login: target })
   rescue ActiveRecord::RecordNotFound
-    puts _('System with login %{login} not found.') % { login: target }
+    raise RMT::CLI::Error.new(_('System with login %{login} not found.') % { login: target })
   end
 end

--- a/spec/lib/rmt/cli/systems_spec.rb
+++ b/spec/lib/rmt/cli/systems_spec.rb
@@ -141,9 +141,9 @@ RSpec.describe RMT::CLI::Systems do
         let(:expected_output) { "System with login 1 not found.\n" }
 
         it 'raises ActiveRecord::RecordNotFound' do
-          expect { described_class.start(argv) }
-            .to output(expected_output).to_stdout
-            .and output('').to_stderr
+          expect { described_class.start(argv) }.to raise_error(SystemExit).and(
+            output(expected_output).to_stderr.and output('').to_stdout
+          )
         end
       end
 
@@ -154,9 +154,9 @@ RSpec.describe RMT::CLI::Systems do
 
         it 'raises ActiveRecord::RecordNotDestroyed' do
           expect_any_instance_of(System).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
-          expect { described_class.start(argv) }
-            .to output(expected_output).to_stdout
-            .and output('').to_stderr
+          expect { described_class.start(argv) }.to raise_error(SystemExit).and(
+            output(expected_output).to_stderr.and output('').to_stdout
+          )
         end
       end
     end


### PR DESCRIPTION
```
ivan@localhost:~/work/rmt> rmt-cli systems remove asdasd >/dev/null
System with login asdasd not found.
ivan@localhost:~/work/rmt> echo $?
1
```

Now the rrror message is printed to `stderr` now and exit status is set to a non-zero value.

`RMT::CLI::Error` exception handling code calls `exit` to set the status code -- this was causing `rspec` to exit prematurely :slightly_smiling_face:  